### PR TITLE
fix: set vscode engine to 1.60.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     ".proto"
   ],
   "engines": {
-    "vscode": "^1.91.0"
+    "vscode": "^1.60.0"
   },
   "activationEvents": [
     "onLanguage:proto3"


### PR DESCRIPTION
This is to support older version of VSCode as we do not have any hardpressed version dependencies.